### PR TITLE
Fix dictionary download

### DIFF
--- a/android/routerKeygen/src/main/AndroidManifest.xml
+++ b/android/routerKeygen/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_SETTINGS" />
     <uses-permission-sdk-23 android:name="android.permission.READ_EXTERNAL_STORAGE"/>
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="22"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
     <application
         android:name=".RouterKeygenApplication"


### PR DESCRIPTION
This hopefully fixes #3. Downloading works on my test device.
It probably isn't the intended fix, but it works for now.